### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball training and games",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Tennis lessons and friendly matches",
+        "schedule": "Wednesdays and Saturdays, 3:00 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["alex@mergington.edu", "sarah@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and sculpture techniques",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["grace@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Theater productions and acting workshops",
+        "schedule": "Thursdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["ryan@mergington.edu", "emily@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop argumentation and public speaking skills",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 16,
+        "participants": ["marcus@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Hands-on experiments and scientific exploration",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["lisa@mergington.edu", "andrew@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate participant exists
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in activity")
+
+    # Remove all occurrences to keep participant lists clean
+    activity["participants"] = [participant for participant in activity["participants"] if participant != email]
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,15 +3,30 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const submitButton = signupForm.querySelector('button[type="submit"]');
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch activities: ${response.status}`);
+      }
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +34,40 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList =
+          details.participants.length > 0
+            ? details.participants
+                .map(
+                  (participant) => `
+                    <li class="participant-item">
+                      <span class="participant-email">${participant}</span>
+                      <button
+                        type="button"
+                        class="remove-participant"
+                        data-activity="${name}"
+                        data-email="${participant}"
+                        aria-label="Remove ${participant} from ${name}"
+                        title="Unregister participant"
+                      >
+                        ×
+                      </button>
+                    </li>
+                  `
+                )
+                .join("")
+            : "<li class=\"empty-participants\">No one has signed up yet.</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants</strong></p>
+            <ul class="participants-list">
+              ${participantsList}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -47,6 +90,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
+    if (submitButton) {
+      submitButton.disabled = true;
+    }
 
     try {
       const response = await fetch(
@@ -59,25 +105,56 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    } finally {
+      if (submitButton) {
+        submitButton.disabled = false;
+      }
+    }
+  });
+
+  // Handle unregister click for participant delete icons
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".remove-participant");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = deleteButton.dataset.activity;
+    const email = deleteButton.dataset.email;
+
+    if (!activity || !email) {
+      showMessage("Unable to remove participant.", "error");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "info");
+        await fetchActivities();
+      } else {
+        showMessage(result.detail || "Failed to unregister participant.", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to unregister participant. Please try again.", "error");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,82 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ffffff 0%, #f2f7ff 100%);
+  border: 1px solid #dbe7ff;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin-left: 0;
+  padding-left: 0;
+  list-style: none;
+  color: #1f2937;
+}
+
+.participants-list li {
+  margin-bottom: 4px;
+  word-break: break-word;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #ffffff;
+  border: 1px solid #e7eefc;
+}
+
+.participant-email {
+  font-size: 14px;
+  color: #22324d;
+}
+
+.remove-participant {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid #ffcdd2;
+  background-color: #fff5f5;
+  color: #c62828;
+  font-size: 16px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.remove-participant:hover {
+  background-color: #ffebee;
+  border-color: #ef9a9a;
+}
+
+.remove-participant:focus-visible {
+  outline: 2px solid #ef9a9a;
+  outline-offset: 1px;
+}
+
+.empty-participants {
+  color: #607089;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import app as app_module
+
+BASELINE_ACTIVITIES = deepcopy(app_module.activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    """Reset in-memory activity data before each test for isolation."""
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(BASELINE_ACTIVITIES))
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(BASELINE_ACTIVITIES))
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,14 @@
+def test_get_activities_returns_expected_shape(client):
+    # Arrange
+    required_fields = {"description", "schedule", "max_participants", "participants"}
+
+    # Act
+    response = client.get("/activities")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+    assert required_fields.issubset(payload["Chess Club"].keys())
+    assert isinstance(payload["Chess Club"]["participants"], list)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,10 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    expected_location = "/static/index.html"
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == expected_location

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,48 @@
+def test_signup_adds_participant_to_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity_name}"
+    assert email in activities_response.json()[activity_name]["participants"]
+
+
+def test_signup_returns_404_when_activity_not_found(client):
+    # Arrange
+    missing_activity = "Robotics Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{missing_activity}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_returns_400_when_student_already_signed_up(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,48 @@
+def test_unregister_removes_participant_from_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {email} from {activity_name}"
+    assert email not in activities_response.json()[activity_name]["participants"]
+
+
+def test_unregister_returns_404_when_activity_not_found(client):
+    # Arrange
+    missing_activity = "Robotics Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{missing_activity}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_when_participant_not_found(client):
+    # Arrange
+    activity_name = "Chess Club"
+    missing_email = "not.registered@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": missing_email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in activity"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the activity sign-up system, including the ability for users to unregister from activities, enhanced participant management in the frontend, UI improvements, and comprehensive automated testing. The changes also ensure better state isolation during testing and expand the set of available activities.

**Backend functionality improvements:**

* Added an endpoint to allow students to unregister from activities, including validation for activity and participant existence.
* Prevented duplicate sign-ups by validating if a student is already registered for an activity.
* Expanded the list of available activities with more options and initial participants in `src/app.py`.

**Frontend enhancements:**

* Updated the frontend to display participant lists for each activity, including a remove ("×") button for each participant. Added logic to handle unregistering participants and improved user feedback with a unified `showMessage` function. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R6-R70) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R157)
* Disabled the submit button during sign-up requests to prevent duplicate submissions and improved error handling. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R93-R95) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R157)

**Styling improvements:**

* Added new CSS styles for the participants section, participant items, and remove buttons to enhance the UI and accessibility.

**Testing improvements:**

* Added a fixture to reset the in-memory activities state before each test for isolation.
* Added backend tests for activities listing, sign-up, and unregister features, including error cases. [[1]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R14) [[2]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R48) [[3]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R48)
* Added a test to verify root URL redirects to the static index page.